### PR TITLE
Greatly improve HLE BIOS implementation plus other fixes

### DIFF
--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -63,6 +63,68 @@ static bool emu_running = false;
 void config_load();
 void config_save();
 
+const char CNTfix_table[19][10]=
+{
+	/* Vandal Hearts */
+	{"SCPS45183"},
+	{"SCPS45183"},
+	{"SLES00204"},
+	{"SLUS00447"},
+	/* Vandal Hearts II */
+	{"SLES02469"},
+	{"SLES02497"},
+	{"SLES02496"},
+	{"SLUS00940"},
+	{"SLPM86251"},
+	{"SLPM86007"},
+	/* Parasite Eve II */
+	{"SLES02561"},
+	{"SLES12562"},
+	{"SLES02562"},
+	{"SLES12560"},
+	{"SLES02560"},
+	{"SLES12559"},
+	{"SLES02559"},
+	{"SLES12558"},
+	{"SLES02558"}
+};
+
+/* Function for automatic patching according to GameID.
+ * It's possible that some of these games have no IDs, like some japanese games i encountered.
+ * I need to check whenever this matters or not for our games.
+ * (Plus it can still be activated in the menu)
+ * Let's hope the IDs are also not shared with other games ! (Homebrew, don't screw it up)
+ * */
+void CheckforCDROMid_applyhacks()
+{
+	uint8_t i;
+	
+	/* Fixes Grandia JP. Need to check if the hack needs to be applied against PAL/US versions too. */
+	extern bool use_clip_368;
+	use_clip_368 = gpu_unai_config_ext.clip_368;
+	if (strncmp(CdromId, "SLPS02124", 9) == 0)
+	{
+		use_clip_368 = 1;
+		return;
+	}
+	
+	/* Apply hack battle fix for Inuyasha - Sengoku Otogi Kassen */
+	if (strncmp(CdromId, "SLPS03503", 9) == 0)
+	{
+		Config.VSyncWA = 1;
+		return;
+	}
+	
+	/* Apply hackfix for Parasite Eve 2, Vandal Hearts I/II */
+	for(i=0;i<sizeof(CNTfix_table);i++)
+	{
+		if (strncmp(CdromId, CNTfix_table[i], 9) == 0)
+		{
+			Config.RCntFix = 1;
+		}
+	}
+}
+
 static void pcsx4all_exit(void)
 {
   if (SDL_MUSTLOCK(screen))
@@ -1385,13 +1447,8 @@ int main (int argc, char **argv)
     }
   }
 
-  extern bool use_clip_368;
-  use_clip_368 = gpu_unai_config_ext.clip_368;
-  if (strncmp(CdromId, "SLPS02124", 9) == 0)
-  {
-    // fix Grandia
-    use_clip_368 = true;
-  }
+  CheckforCDROMid_applyhacks();
+  
   joy_init();
 
   if (filename[0] != '\0')

--- a/src/ppf.cpp
+++ b/src/ppf.cpp
@@ -181,7 +181,7 @@ void BuildPPFCache() {
 	FILE			*ppffile;
 	char			buffer[12];
 	char			method, undo = 0, blockcheck = 0;
-	int				dizlen, dizyn;
+	int				dizlen = 0, dizyn;
 	unsigned char	ppfmem[512];
 	char			szPPF[MAXPATHLEN];
 	int				count, seekpos, pos;

--- a/src/psxinterpreter.cpp
+++ b/src/psxinterpreter.cpp
@@ -520,13 +520,19 @@ void psxSLTU(void) 	{ if (!_Rd_) return; _rRd_ = _u32(_rRs_) < _u32(_rRt_); }	//
 * Format:  OP rs, rt                                     *
 *********************************************************/
 void psxDIV(void) {
-	if (_i32(_rRt_) != 0) {
+	if (!_i32(_rRt_)) {
+		if (_i32(_rRs_) & 0x80000000) {
+			_i32(_rLo_) = 1;
+		} else {
+		_i32(_rLo_) = 0xFFFFFFFF;
+		_i32(_rHi_) = _i32(_rRs_);
+		}
+	} else if (_i32(_rRs_) == 0x80000000 && _i32(_rRt_) == 0xFFFFFFFF) {
+		_i32(_rLo_) = 0x80000000;
+		_i32(_rHi_) = 0;
+	} else {
 		_i32(_rLo_) = _i32(_rRs_) / _i32(_rRt_);
 		_i32(_rHi_) = _i32(_rRs_) % _i32(_rRt_);
-	}
-	else {
-		_i32(_rLo_) = _i32(_rRs_) >= 0 ? 0xffffffff : 1;
-		_i32(_rHi_) = _i32(_rRs_);
 	}
 }
 

--- a/src/psxmem.h
+++ b/src/psxmem.h
@@ -28,8 +28,8 @@
 #define _SWAP16(b) ((((unsigned char*)&(b))[0]&0xff) | (((unsigned char*)&(b))[1]&0xff)<<8)
 #define _SWAP32(b) ((((unsigned char*)&(b))[0]&0xff) | ((((unsigned char*)&(b))[1]&0xff)<<8) | ((((unsigned char*)&(b))[2]&0xff)<<16) | (((unsigned char*)&(b))[3]<<24))
 
-#define SWAP16(v) ((((v)&0xff00)>>8) +(((v)&0xff)<<8))
-#define SWAP32(v) ((((v)&0xff000000ul)>>24) + (((v)&0xff0000ul)>>8) + (((v)&0xff00ul)<<8) +(((v)&0xfful)<<24))
+#define SWAP16(v) ((((v) & 0xff00) >> 8) | (((v) & 0xff) << 8))
+#define SWAP32(v) ((((v) & 0xff000000ul) >> 24) | (((v) & 0xff0000ul) >> 8) | (((v) & 0xff00ul)<<8) | (((v) & 0xfful) << 24))
 #define SWAPu32(v) SWAP32((u32)(v))
 #define SWAPs32(v) SWAP32((s32)(v))
 

--- a/src/sio.cpp
+++ b/src/sio.cpp
@@ -254,10 +254,12 @@ void sioWrite8(unsigned char value) {
 				if (!sioMcdInserted(MCD2))
 					goto no_device;
 				memcpy(psxSio.buf, psxSio.cardh2, 4);
+				if (!Config.Mcd2[0]) psxSio.buf[3]=0; // is card 2 plugged?
 			} else {
 				if (!sioMcdInserted(MCD1))
 					goto no_device;
 				memcpy(psxSio.buf, psxSio.cardh1, 4);
+				if (!Config.Mcd1[0]) psxSio.buf[2]=0; // is card 1 plugged? (Codename Tenka)
 			}
 			psxSio.StatReg |= RX_RDY;
 			psxSio.parp = 0;

--- a/src/sio.h
+++ b/src/sio.h
@@ -57,7 +57,7 @@ int sioFreeze(void* f, FreezeMode mode);
 // Memcard operations //
 ////////////////////////
 
-#define MCD_SIZE	(1024 * 8 * 16)
+#define MCD_SIZE	(1024 * (8 * 16))
 
 enum MemcardNum {
 	MCD1 = 0,


### PR DESCRIPTION
This merges some fixes from upstream and from random users. 
These fixed a number of issues with Memory saves on Digimon World, Lego Racers, Parasite Eve II...
LEGO Racers could not save before, this now succeeds, indicating it is the right behaviour. (This game is incredibly sensitive to the placement of DeliverEvents)

I also improved the HLE implementation according to nocash's PSX documentation and implementing a few functions (mostly unimportant ones).
I also did some changes to BiosException as to make it follow nocash's doc more closely : seems like this fixed games like Medievil II without resorting to hacks.

Upstream also had a fix for some PSX games like NFS4 that don't use slashes.

As for frontend, game hacks are now checked against a table of known game IDs and applied accordingly : Users don't have to do anything unless it goes really wrong of course...