### PR TITLE
added cmake support, with code cleanup & win32 compile fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+if("${MODEL}" MATCHES "gcw0|rs97|rg350")
+  set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/mips32-linux-gcc.cmake")
+endif()
+
+project(pcsx4all)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(src)

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -44,7 +44,7 @@ endif
 CFLAGS += -D$(shell echo $(GPU) | tr a-z A-Z)
 CFLAGS += -D$(shell echo $(SPU) | tr a-z A-Z)
 
-LDFLAGS = $(SDL_LIBS) -lSDL_mixer -lSDL_image -lz
+LDFLAGS = $(SDL_LIBS) -lz #-lSDL_mixer -lSDL_image
 
 OBJDIRS = \
 	obj obj/gpu obj/gpu/$(GPU) obj/spu obj/spu/$(SPU) \
@@ -83,6 +83,7 @@ OBJS += obj/spu/$(SPU)/spu.o
 
 OBJS += obj/port/$(PORT)/port.o
 OBJS += obj/port/$(PORT)/frontend.o
+OBJS += obj/port/$(PORT)/cdrom_hacks.o
 
 OBJS += obj/plugin_lib/perfmon.o
 

--- a/cmake/mips32-linux-gcc.cmake
+++ b/cmake/mips32-linux-gcc.cmake
@@ -1,0 +1,53 @@
+set(CMAKE_SYSTEM_NAME "Linux")
+
+if("${CROSS}" STREQUAL "")
+  set(CROSS mipsel-linux-)
+endif ()
+
+set(MIPS_FLAGS "${MIPS_FLAGS} -mips32r2 -DDYNAREC_SKIP_DCACHE_FLUSH -DTMPFS_MIRRORING -DTMPFS_DIR=/tmp -mno-abicalls -fno-PIC -mno-check-zero-division")
+
+if("${MODEL}" STREQUAL "rs97")
+  set(MIPS_FLAGS "${MIPS_FLAGS} -DRS97")
+elseif("${MODEL}" STREQUAL "rg350")
+  set(MIPS_FLAGS "${MIPS_FLAGS} -DRG350")
+else()
+  set(MIPS_FLAGS "${MIPS_FLAGS} -DGCW_ZERO")
+endif()
+
+if("${TOOLCHAIN_PREFIX}" STREQUAL "")
+  set(TOOLCHAIN_PREFIX "/opt/${MODEL}-toolchain")
+endif()
+
+set(TOOL_OS_SUFFIX "")
+if(CMAKE_HOST_WIN32)
+ set(TOOL_OS_SUFFIX ".exe")
+endif()
+
+set(CMAKE_SYSTEM_PROCESSOR "mipsel")
+set(CMAKE_C_COMPILER   "${TOOLCHAIN_PREFIX}/bin/${CROSS}gcc${TOOL_OS_SUFFIX}"     CACHE PATH "C compiler")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_PREFIX}/bin/${CROSS}g++${TOOL_OS_SUFFIX}"     CACHE PATH "C++ compiler")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_PREFIX}/bin/${CROSS}gcc${TOOL_OS_SUFFIX}"     CACHE PATH "assembler")
+set(CMAKE_STRIP        "${TOOLCHAIN_PREFIX}/bin/${CROSS}strip${TOOL_OS_SUFFIX}"   CACHE PATH "strip")
+set(CMAKE_AR           "${TOOLCHAIN_PREFIX}/bin/${CROSS}ar${TOOL_OS_SUFFIX}"      CACHE PATH "archive")
+set(CMAKE_LINKER       "${TOOLCHAIN_PREFIX}/bin/${CROSS}ld${TOOL_OS_SUFFIX}"      CACHE PATH "linker")
+set(CMAKE_NM           "${TOOLCHAIN_PREFIX}/bin/${CROSS}nm${TOOL_OS_SUFFIX}"      CACHE PATH "nm")
+set(CMAKE_OBJCOPY      "${TOOLCHAIN_PREFIX}/bin/${CROSS}objcopy${TOOL_OS_SUFFIX}" CACHE PATH "objcopy")
+set(CMAKE_OBJDUMP      "${TOOLCHAIN_PREFIX}/bin/${CROSS}objdump${TOOL_OS_SUFFIX}" CACHE PATH "objdump")
+set(CMAKE_RANLIB       "${TOOLCHAIN_PREFIX}/bin/${CROSS}ranlib${TOOL_OS_SUFFIX}"  CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS          "${CMAKE_C_FLAGS} ${MIPS_CFLAGS}"     CACHE STRING "C flags")
+set(CMAKE_CXX_FLAGS        "${CMAKE_CXX_FLAGS} ${MIPS_CXXFLAGS}" CACHE STRING "C++ flags")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed -Wl,--gc-sections" CACHE STRING "Executable linker flags")
+
+# No runtime cpu detect for mipsel-linux-gcc.
+set(CONFIG_RUNTIME_CPU_DETECT 0 CACHE BOOL "")
+
+execute_process(COMMAND ${CMAKE_C_COMPILER} -print-sysroot OUTPUT_VARIABLE MIPS_SYSROOT_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(CMAKE_FIND_ROOT_PATH "${MIPS_SYSROOT_PATH}")
+
+if(NOT CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+endif()
+if(NOT CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,88 @@
+option(USE_GPULIB "Use gpulib from pcsx rearmed" ON)
+set(PORT sdl)
+set(GPU gpu_unai)
+set(SPU spu_pcsxrearmed)
+
+find_package(SDL REQUIRED)
+find_package(ZLIB REQUIRED)
+
+set(SRC_FILES
+    r3000a.c misc.c plugins.c psxmem.c psxhw.c
+    psxcounters.c psxdma.c psxbios.c psxhle.c psxevents.c
+    psxcommon.c
+    plugin_lib/plugin_lib.c plugin_lib/pl_sshot.c plugin_lib/perfmon.c
+    psxinterpreter.c
+    mdec.c decode_xa.c
+    cdriso.c cdrom.c ppf.c
+    sio.c pad.c
+    gte.c
+    spu/${SPU}/spu.c
+    port/${PORT}/port.c
+    port/${PORT}/frontend.c
+    port/${PORT}/cdrom_hacks.c
+    )
+
+if(USE_GPULIB)
+    set(GPULIB_FLAG USE_GPULIB)
+    set(SRC_FILES ${SRC_FILES}
+        gpu/${GPU}/gpulib_if.cpp
+        gpu/gpulib/gpu.c gpu/gpulib/vout_port.c
+        )
+endif()
+
+if("${SPU}" STREQUAL "spu_pcsxrearmed")
+    set(SOUND_DRIVERS sdl)
+
+    set(SRC_FILES ${SRC_FILES}
+        spu/spu_pcsxrearmed/dma.c spu/spu_pcsxrearmed/freeze.c
+        spu/spu_pcsxrearmed/out.c spu/spu_pcsxrearmed/nullsnd.c
+        spu/spu_pcsxrearmed/registers.c)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+        set(SRC_FILES ${SRC_FILES} spu/spu_pcsxrearmed/arm_utils.c)
+    endif()
+    if(HAVE_C64_TOOLS)
+        set(SPU_FLAGS ${SPU_FLAGS} C64X_DSP)
+        set(SRC_FILES ${SRC_FILES} spu/spu_pcsxrearmed/spu_c64x.c)
+    endif()
+    if("${SOUND_DRIVERS}" MATCHES "oss")
+        set(SPU_FLAGS ${SPU_FLAGS} HAVE_OSS)
+        set(SRC_FILES ${SRC_FILES} spu/spu_pcsxrearmed/oss.c)
+    endif()
+    if("${SOUND_DRIVERS}" MATCHES "alsa")
+        set(SPU_FLAGS ${SPU_FLAGS} HAVE_ALSA)
+        set(SRC_FILES ${SRC_FILES} spu/spu_pcsxrearmed/alsa.c)
+    endif()
+    if("${SOUND_DRIVERS}" MATCHES "sdl")
+        set(SPU_FLAGS ${SPU_FLAGS} HAVE_SDL)
+        set(SRC_FILES ${SRC_FILES} spu/spu_pcsxrearmed/sdl.c)
+    endif()
+    if("${SOUND_DRIVERS}" MATCHES "pulseaudio")
+        set(SPU_FLAGS ${SPU_FLAGS} HAVE_PULSE)
+        set(SRC_FILES ${SRC_FILES} spu/spu_pcsxrearmed/pulseaudio.c)
+    endif()
+    if("${SOUND_DRIVERS}" MATCHES "libretro")
+        set(SPU_FLAGS ${SPU_FLAGS} HAVE_LIBRETRO)
+    endif()
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
+
+add_executable(${PROJECT_NAME} ${SRC_FILES})
+
+string(TOUPPER "${GPU}" GPU_FLAG)
+string(TOUPPER "${SPU}" SPU_FLAG)
+set(GPU_FLAGS ${GPU_FLAGS} ${GPU_FLAG} ${GPULIB_FLAG})
+set(SPU_FLAGS ${SPU_FLAGS} ${SPU_FLAG})
+
+if(MINGW)
+    set(EXTRA_FLAGS __USE_MINGW_ANSI_STDIO=1)
+endif()
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE GCW_ZERO XA_HACK
+    "INLINE=static __inline__" "asm=__asm__ __volatile__"
+    ${GPU_FLAGS} ${SPU_FLAGS} ${EXTRA_FLAGS})
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-format-truncation)
+target_include_directories(${PROJECT_NAME} PRIVATE ${SDL_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS}
+    . spu/${SPU} gpu/${GPU} port/${PORT} plugin_lib)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${SDL_LIBRARY} ${ZLIB_LIBRARIES})

--- a/src/cdriso.c
+++ b/src/cdriso.c
@@ -438,7 +438,7 @@ static int parsetoc(const char *isofile) {
 	// parse the .toc file
 	while (fgets(linebuf, sizeof(linebuf), fi) != NULL) {
 		// search for tracks
-		strncpy(tmp, linebuf, sizeof(linebuf));
+		strncpy(tmp, linebuf, sizeof(tmp));
 		token = strtok(tmp, " ");
 
 		if (token == NULL) continue;
@@ -601,7 +601,7 @@ static int parsecue(const char *isofile) {
 	sector_offs = 2 * 75;
 
 	while (fgets(linebuf, sizeof(linebuf), fi) != NULL) {
-		strncpy(dummy, linebuf, sizeof(linebuf));
+		strncpy(dummy, linebuf, sizeof(dummy));
 		token = strtok(dummy, " ");
 
 		if (token == NULL) {

--- a/src/cdrom.c
+++ b/src/cdrom.c
@@ -924,7 +924,7 @@ void cdrInterrupt()
 			}
 			cdr.Result[0] |= (cdr.Result[1] >> 4) & 0x08;
 
-			strncpy((char *)&cdr.Result[4], "PCSX", 4);
+			strncpy((char *)&cdr.Result[4], "PCSX", 5);
 			cdr.Stat = Complete;
 			break;
 

--- a/src/gpu/gpu_unai/gpu_raster_image.h
+++ b/src/gpu/gpu_unai/gpu_raster_image.h
@@ -17,7 +17,9 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
  ***************************************************************************/
+#ifndef _WIN32
 #include <sys/ioctl.h>
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef USE_GPULIB

--- a/src/gpu/gpulib/gpu.c
+++ b/src/gpu/gpulib/gpu.c
@@ -11,12 +11,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/ioctl.h>
 #include <fcntl.h>
-#include <sys/mman.h>
 #include <unistd.h>
 #include <SDL.h>
+#ifndef _WIN32
+#include <sys/mman.h>
 #include <sys/ioctl.h>
+#endif
 
 #include "plugins.h"    // For GPUFreeze_t, GPUScreenInfo_t
 #include "gpu.h"

--- a/src/gpu/gpulib/vout_port.c
+++ b/src/gpu/gpulib/vout_port.c
@@ -14,8 +14,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/ioctl.h>
+#endif
 
 #include "port.h"
 #include "gpu.h"

--- a/src/misc.c
+++ b/src/misc.c
@@ -482,8 +482,8 @@ int Load(const char *ExePath) {
 	void *mem;
 	u32 new_pc;
 	
-	strncpy(CdromId, "SLUS99999", 9);
-	strncpy(CdromLabel, "SLUS_999.99", 11);
+	strncpy(CdromId, "SLUS99999", 10);
+	strncpy(CdromLabel, "SLUS_999.99", 12);
 
 	tmpFile = fopen(ExePath, "rb");
 	if (tmpFile == NULL) {

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -144,6 +144,7 @@ unsigned int CALLBACK SPUgetADPCMBufferRoom(void); //senquack - added function
 int  CALLBACK SPUplayCDDAchannel(short *, int);
 long CALLBACK SPUconfigure(void);
 void CALLBACK SPUasync(uint32_t, uint32_t);
+long CALLBACK SPUfreeze(uint32_t, SPUFreeze_t *, uint32_t);
 
 #ifdef SPU_PCSXREARMED
 void CALLBACK SPUregisterCallback(void CALLBACK (*callback)(void));

--- a/src/port/sdl/frontend.c
+++ b/src/port/sdl/frontend.c
@@ -2130,6 +2130,8 @@ static void ShowMenu(MENU *menu)
   // general copyrights info
 #if defined(RS97)
   port_printf( 8 * 8, 10, "PCSX4ALL v2.4 for RetroGame");
+#elif defined(RG350)
+  port_printf( 8 * 8, 10, "pcsx4all 2.4 for RG-350");
 #else
   port_printf( 8 * 8, 10, "pcsx4all 2.4 for GCW-Zero");
 #endif

--- a/src/port/sdl/frontend.c
+++ b/src/port/sdl/frontend.c
@@ -6,7 +6,9 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef _WIN32
 #include <sys/ioctl.h>
+#endif
 #include <SDL.h>
 
 #include "port.h"

--- a/src/port/sdl/port.c
+++ b/src/port/sdl/port.c
@@ -9,10 +9,12 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include <sys/mman.h>
 #include <unistd.h>
 #include <SDL.h>
+#ifndef _WIN32
+#include <sys/mman.h>
 #include <sys/ioctl.h>
+#endif
 
 #ifdef RUMBLE
 #include <shake.h>

--- a/src/port/sdl/port.c
+++ b/src/port/sdl/port.c
@@ -1430,11 +1430,11 @@ int main (int argc, char **argv)
 
   atexit(pcsx4all_exit);
 
-	#ifdef SDL_TRIPLEBUF
-		int flags = SDL_HWSURFACE | SDL_TRIPLEBUF;
-	#else
-		int flags = SDL_HWSURFACE | SDL_DOUBLEBUF;
-	#endif
+#ifdef SDL_TRIPLEBUF
+  int flags = SDL_HWSURFACE | SDL_TRIPLEBUF;
+#else
+  int flags = SDL_HWSURFACE | SDL_DOUBLEBUF;
+#endif
 	
   screen = SDL_SetVideoMode(320, 240, 16, flags);
   if (!screen)
@@ -1620,21 +1620,25 @@ void port_printf(int x, int y, const char *text)
     0x00,0x00,0x76,0xDC,0x00,0x00,0x00,0x00,0x10,0x28,0x10,0x54,0xAA,0x44,0x00,0x00,
   };
 
-  int interval = 1;
+  int interval = 1, row = 320 * interval;
   unsigned short *screen = (SCREEN + x + y * 320);
+  int len = strlen(text);
 
-  for (int i = 0; i < strlen(text); i++)
+  for (int i = 0; i < len; i++)
   {
+    int pos = 0;
     for (int l = 0; l < 8; l++)
     {
-      screen[l * 320 * interval + 0] = (fontdata8x8[((text[i]) * 8) + l] & 0x80) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 1] = (fontdata8x8[((text[i]) * 8) + l] & 0x40) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 2] = (fontdata8x8[((text[i]) * 8) + l] & 0x20) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 3] = (fontdata8x8[((text[i]) * 8) + l] & 0x10) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 4] = (fontdata8x8[((text[i]) * 8) + l] & 0x08) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 5] = (fontdata8x8[((text[i]) * 8) + l] & 0x04) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 6] = (fontdata8x8[((text[i]) * 8) + l] & 0x02) ? 0xffff:0x0000;
-      screen[l * 320 * interval + 7] = (fontdata8x8[((text[i]) * 8) + l] & 0x01) ? 0xffff:0x0000;
+      unsigned char data = fontdata8x8[((text[i]) * 8) + l];
+      screen[pos    ] = (data & 0x80) ? 0xffff:0x0000;
+      screen[pos + 1] = (data & 0x40) ? 0xffff:0x0000;
+      screen[pos + 2] = (data & 0x20) ? 0xffff:0x0000;
+      screen[pos + 3] = (data & 0x10) ? 0xffff:0x0000;
+      screen[pos + 4] = (data & 0x08) ? 0xffff:0x0000;
+      screen[pos + 5] = (data & 0x04) ? 0xffff:0x0000;
+      screen[pos + 6] = (data & 0x02) ? 0xffff:0x0000;
+      screen[pos + 7] = (data & 0x01) ? 0xffff:0x0000;
+      pos += row;
     }
     screen += 8;
   }

--- a/src/port/sdl/port.c
+++ b/src/port/sdl/port.c
@@ -572,9 +572,8 @@ static uint16_t pad2 = 0xFFFF;
 
 static uint16_t pad1_buttons = 0xFFFF;
 
-static unsigned short analog1 = 0,tmp_axis=0;
+static unsigned short analog1 = 0;
 static int menu_check = 0;
-static int select_count = 0;
 uint8_t use_speedup = 0;
 SDL_Joystick * sdl_joy[2];
 #define joy_commit_range    2048

--- a/src/ppf.c
+++ b/src/ppf.c
@@ -206,7 +206,7 @@ void BuildPPFCache() {
 	buffer[10] = CdromId[8];
 	buffer[11] = '\0';
 
-	sprintf(szPPF, "%s/%s", Config.PatchesDir, buffer);
+	snprintf(szPPF, sizeof(szPPF), "%s/%s", Config.PatchesDir, buffer);
 
 	printf("Looking for patch %s\n", szPPF);
 

--- a/src/psxinterpreter.c
+++ b/src/psxinterpreter.c
@@ -968,6 +968,9 @@ static void intExecuteBlock(unsigned target_pc) {
 static void intClear(u32 Addr, u32 Size) {
 }
 
+static void intNotify(int note, void *data) {
+}
+
 static void intShutdown(void) {
 }
 
@@ -992,5 +995,6 @@ R3000Acpu psxInt = {
 	intExecute,
 	intExecuteBlock,
 	intClear,
+	intNotify,
 	intShutdown
 };

--- a/src/spu/spu_pcsxrearmed/adsr.c
+++ b/src/spu/spu_pcsxrearmed/adsr.c
@@ -217,6 +217,7 @@ done:
  return ns;
 }
 
+#if defined(THREAD_ENABLED) || defined(WANT_THREAD_CODE)
 static int SkipADSR(ADSRInfoEx *adsr, int ns_to)
 {
  int EnvelopeVol = adsr->EnvelopeVol;
@@ -343,6 +344,7 @@ done:
  adsr->EnvelopeVol = EnvelopeVol;
  return ns;
 }
+#endif
 
 #endif
 


### PR DESCRIPTION
1. warning cleanup
2. fixed win32 build
3. added cmake support (use `cmake -DMODEL=rs97/rs350/gcw0` to compile for mips targets), x86 build is also supported(tested under msys2 and linux)
4. minor fixes and tweaks